### PR TITLE
fix(elm): remove ns that causes error in 0.19.1

### DIFF
--- a/src/Html/Parser/Util.elm
+++ b/src/Html/Parser/Util.elm
@@ -59,4 +59,4 @@ toAttribute ( name, value ) =
 
 svgNode : String -> List (Attribute msg) -> List (Html msg) -> Html msg
 svgNode =
-    Elm.Kernel.VirtualDom.nodeNS "http://www.w3.org/2000/svg"
+    VirtualDom.nodeNS "http://www.w3.org/2000/svg"


### PR DESCRIPTION
Hi,

Thank you for your package.
I upgraded my Elm version to 0.19.1 today then I got the following that I pasted at the bottom.
After I copied your package directly to my project I got this error which I fixed and sent a PR.

**Inline package error:**

> I cannot find a `Elm.Kernel.VirtualDom.nodeNS` variable:
> 
> 62|     Elm.Kernel.VirtualDom.nodeNS "http://www.w3.org/2000/svg"
>         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> I cannot find a `Elm.Kernel.VirtualDom` import. These names seem close though:
> 
>     VirtualDom.nodeNS
>     VirtualDom.node
>     VirtualDom.on
>     VirtualDom.keyedNodeNS
 
 

**Referenced package error:**


> I ran into a compilation error when trying to build the following package:
> 
>     abinayasudhir/html-parser 1.0.3
> 
> This probably means it has package constraints that are too wide. It may be
> possible to tweak your elm.json to avoid the root problem as a stopgap. Head
> over to https://elm-lang.org/community to get help figuring out how to take this
> path!
> 
> Note: To help with the root problem, please report this to the package author
> along with the following information:
> 
>     elm/core 1.0.4
>     elm/html 1.0.0
>     elm/parser 1.1.0
>     elm/virtual-dom 1.0.2
>     rtfeldman/elm-hex 1.0.0
> 
> If you want to help out even more, try building the package locally. That should
> give you much more specific information about why this package is failing to
> build, which will in turn make it easier for the package author to fix it!
> 
> Dependency problem!